### PR TITLE
Add settings for server and proxy (tor) and handle dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 ARG ARCH
 ARG SPARROW_VERSION
 ARG SPARROW_DEBVERSION
-
-ARG SPARROW_PGP_SIG=E94618334C674B40
+ARG SPARROW_PGP_SIG
 
 RUN \
   echo "**** install packages ****" && \
@@ -20,6 +19,7 @@ RUN \
     python3-xdg \
     yq \
     wget \
+    socat \
     gnupg && \
   echo "**** xfce tweaks ****" && \
   rm -f /etc/xdg/autostart/xscreensaver.desktop && \
@@ -41,21 +41,21 @@ RUN \
     "aarch64") SPARROW_ARCH="arm64";; \
     "x86_64") SPARROW_ARCH="amd64";; \
     *) echo "Dockerfile does not support this platform"; exit 1 ;; \
-    esac && \
-    # sparrow requires this directory to exist
-    mkdir -p /usr/share/desktop-directories/ && \
-    # Download and install Sparrow (todo: gpg sig verification)
-    wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb \
-                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt \
-                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt.asc \
-                 https://keybase.io/craigraw/pgp_keys.asc && \
-    # verify pgp and sha signatures
-    gpg --import pgp_keys.asc && \
-    gpg --status-fd 1 --verify sparrow-${SPARROW_VERSION}-manifest.txt.asc | grep -q "GOODSIG ${PGP_SIG}" || exit 1 && \
-    sha256sum --check sparrow-${SPARROW_VERSION}-manifest.txt --ignore-missing || exit 1 && \
-    apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb && \
-    # cleanup
-    rm ./sparrow* ./pgp_keys.asc
+  esac && \
+  # sparrow requires this directory to exist
+  mkdir -p /usr/share/desktop-directories/ && \
+  # Download and install Sparrow (todo: gpg sig verification)
+  wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb \
+                https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt \
+                https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt.asc \
+                https://keybase.io/craigraw/pgp_keys.asc && \
+  # verify pgp and sha signatures
+  gpg --import pgp_keys.asc && \
+  gpg --status-fd 1 --verify sparrow-${SPARROW_VERSION}-manifest.txt.asc | grep -q "GOODSIG ${PGP_SIG}" || exit 1 && \
+  sha256sum --check sparrow-${SPARROW_VERSION}-manifest.txt --ignore-missing || exit 1 && \
+  apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb && \
+  # cleanup
+  rm ./sparrow* ./pgp_keys.asc
 
 # add local files
 COPY /root /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 
 # these are specified in Makefile
 ARG ARCH
+ARG PLATFORM
 ARG SPARROW_VERSION
 ARG SPARROW_DEBVERSION
 ARG SPARROW_PGP_SIG
@@ -17,10 +18,10 @@ RUN \
     tumbler \
     thunar \
     python3-xdg \
-    yq \
     wget \
     socat \
     gnupg && \
+  wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_${PLATFORM} && chmod +x /usr/local/bin/yq && \
   echo "**** xfce tweaks ****" && \
   rm -f /etc/xdg/autostart/xscreensaver.desktop && \
   sed -i 's|</applications>|  <application title="Sparrow" type="normal">\n    <maximized>yes</maximized>\n  </application>\n</applications>|' /etc/xdg/openbox/rc.xml && \
@@ -37,15 +38,10 @@ RUN \
 # Sparrow
 RUN \
   echo "**** install Sparrow ****" && \
-  case ${ARCH:-x86_64} in \
-    "aarch64") SPARROW_ARCH="arm64";; \
-    "x86_64") SPARROW_ARCH="amd64";; \
-    *) echo "Dockerfile does not support this platform"; exit 1 ;; \
-  esac && \
   # sparrow requires this directory to exist
   mkdir -p /usr/share/desktop-directories/ && \
   # Download and install Sparrow (todo: gpg sig verification)
-  wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb \
+  wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${PLATFORM}.deb \
                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt \
                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt.asc \
                 https://keybase.io/craigraw/pgp_keys.asc && \
@@ -53,7 +49,7 @@ RUN \
   gpg --import pgp_keys.asc && \
   gpg --status-fd 1 --verify sparrow-${SPARROW_VERSION}-manifest.txt.asc | grep -q "GOODSIG ${PGP_SIG}" || exit 1 && \
   sha256sum --check sparrow-${SPARROW_VERSION}-manifest.txt --ignore-missing || exit 1 && \
-  apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb && \
+  apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${PLATFORM}.deb && \
   # cleanup
   rm ./sparrow* ./pgp_keys.asc
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,6 +2,7 @@ FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-debianbookworm
 
 # these are specified in Makefile
 ARG ARCH
+ARG PLATFORM
 ARG SPARROW_VERSION
 ARG SPARROW_DEBVERSION
 ARG SPARROW_PGP_SIG
@@ -17,10 +18,10 @@ RUN \
     tumbler \
     thunar \
     python3-xdg \
-    yq \
     wget \
     socat \
     gnupg && \
+  wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_${PLATFORM} && chmod +x /usr/local/bin/yq && \
   echo "**** xfce tweaks ****" && \
   rm -f /etc/xdg/autostart/xscreensaver.desktop && \
   sed -i 's|</applications>|  <application title="Sparrow" type="normal">\n    <maximized>yes</maximized>\n  </application>\n</applications>|' /etc/xdg/openbox/rc.xml && \
@@ -37,15 +38,10 @@ RUN \
 # Sparrow
 RUN \
   echo "**** install Sparrow ****" && \
-  case ${ARCH:-x86_64} in \
-    "aarch64") SPARROW_ARCH="arm64";; \
-    "x86_64") SPARROW_ARCH="amd64";; \
-    *) echo "Dockerfile does not support this platform"; exit 1 ;; \
-  esac && \
   # sparrow requires this directory to exist
   mkdir -p /usr/share/desktop-directories/ && \
   # Download and install Sparrow (todo: gpg sig verification)
-  wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb \
+  wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${PLATFORM}.deb \
                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt \
                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt.asc \
                 https://keybase.io/craigraw/pgp_keys.asc && \
@@ -53,7 +49,7 @@ RUN \
   gpg --import pgp_keys.asc && \
   gpg --status-fd 1 --verify sparrow-${SPARROW_VERSION}-manifest.txt.asc | grep -q "GOODSIG ${PGP_SIG}" || exit 1 && \
   sha256sum --check sparrow-${SPARROW_VERSION}-manifest.txt --ignore-missing || exit 1 && \
-  apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb && \
+  apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${PLATFORM}.deb && \
   # cleanup
   rm ./sparrow* ./pgp_keys.asc
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,8 +4,7 @@ FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-debianbookworm
 ARG ARCH
 ARG SPARROW_VERSION
 ARG SPARROW_DEBVERSION
-
-ARG SPARROW_PGP_SIG=E94618334C674B40
+ARG SPARROW_PGP_SIG
 
 RUN \
   echo "**** install packages ****" && \
@@ -20,6 +19,7 @@ RUN \
     python3-xdg \
     yq \
     wget \
+    socat \
     gnupg && \
   echo "**** xfce tweaks ****" && \
   rm -f /etc/xdg/autostart/xscreensaver.desktop && \
@@ -41,21 +41,21 @@ RUN \
     "aarch64") SPARROW_ARCH="arm64";; \
     "x86_64") SPARROW_ARCH="amd64";; \
     *) echo "Dockerfile does not support this platform"; exit 1 ;; \
-    esac && \
-    # sparrow requires this directory to exist
-    mkdir -p /usr/share/desktop-directories/ && \
-    # Download and install Sparrow (todo: gpg sig verification)
-    wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb \
-                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt \
-                 https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt.asc \
-                 https://keybase.io/craigraw/pgp_keys.asc && \
-    # verify pgp and sha signatures
-    gpg --import pgp_keys.asc && \
-    gpg --status-fd 1 --verify sparrow-${SPARROW_VERSION}-manifest.txt.asc | grep -q "GOODSIG ${PGP_SIG}" || exit 1 && \
-    sha256sum --check sparrow-${SPARROW_VERSION}-manifest.txt --ignore-missing || exit 1 && \
-    apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb && \
-    # cleanup
-    rm ./sparrow* ./pgp_keys.asc
+  esac && \
+  # sparrow requires this directory to exist
+  mkdir -p /usr/share/desktop-directories/ && \
+  # Download and install Sparrow (todo: gpg sig verification)
+  wget --quiet https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb \
+                https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt \
+                https://github.com/sparrowwallet/sparrow/releases/download/${SPARROW_VERSION}/sparrow-${SPARROW_VERSION}-manifest.txt.asc \
+                https://keybase.io/craigraw/pgp_keys.asc && \
+  # verify pgp and sha signatures
+  gpg --import pgp_keys.asc && \
+  gpg --status-fd 1 --verify sparrow-${SPARROW_VERSION}-manifest.txt.asc | grep -q "GOODSIG ${PGP_SIG}" || exit 1 && \
+  sha256sum --check sparrow-${SPARROW_VERSION}-manifest.txt --ignore-missing || exit 1 && \
+  apt-get install -y ./sparrow_${SPARROW_DEBVERSION}_${SPARROW_ARCH}.deb && \
+  # cleanup
+  rm ./sparrow* ./pgp_keys.asc
 
 # add local files
 COPY /root /

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ else
 	mkdir -p docker-images
 	docker buildx build --tag start9/$(PKG_ID)/main:$(PKG_VERSION) \
 		--build-arg ARCH=aarch64 \
+		--build-arg PLATFORM=arm64 \
 		--build-arg SPARROW_VERSION=$(SPARROW_VERSION) \
 		--build-arg SPARROW_DEBVERSION=$(SPARROW_DEBVERSION) \
 		--build-arg SPARROW_PGP_SIG=$(SPARROW_PGP_SIG) \
@@ -57,6 +58,7 @@ else
 	mkdir -p docker-images
 	docker buildx build --tag start9/$(PKG_ID)/main:$(PKG_VERSION) \
 		--build-arg ARCH=x86_64 \
+		--build-arg PLATFORM=amd64 \
 		--build-arg SPARROW_VERSION=$(SPARROW_VERSION) \
 		--build-arg SPARROW_DEBVERSION=$(SPARROW_DEBVERSION) \
 		--build-arg SPARROW_PGP_SIG=$(SPARROW_PGP_SIG) \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SPARROW_VERSION := 1.8.2
 SPARROW_DEBVERSION := 1.8.2-1
+SPARROW_PGP_SIG := E94618334C674B40
 
 PKG_ID := $(shell yq e ".id" manifest.yaml)
 PKG_VERSION := $(shell yq e ".version" manifest.yaml)
@@ -46,6 +47,7 @@ else
 		--build-arg ARCH=aarch64 \
 		--build-arg SPARROW_VERSION=$(SPARROW_VERSION) \
 		--build-arg SPARROW_DEBVERSION=$(SPARROW_DEBVERSION) \
+		--build-arg SPARROW_PGP_SIG=$(SPARROW_PGP_SIG) \
 		--platform=linux/arm64 -o type=docker,dest=docker-images/aarch64.tar -f Dockerfile.aarch64 .
 endif
 
@@ -57,6 +59,7 @@ else
 		--build-arg ARCH=x86_64 \
 		--build-arg SPARROW_VERSION=$(SPARROW_VERSION) \
 		--build-arg SPARROW_DEBVERSION=$(SPARROW_DEBVERSION) \
+		--build-arg SPARROW_PGP_SIG=$(SPARROW_PGP_SIG) \
 		--platform=linux/amd64 -o type=docker,dest=docker-images/x86_64.tar .
 endif
 

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -5,9 +5,9 @@ echo
 export PUID=1000
 export PGID=1000
 export TZ=Etc/UTC
-export TITLE="$(yq -r '.title' /root/data/start9/config.yaml)"
-export CUSTOM_USER="$(yq -r '.username' /root/data/start9/config.yaml)"
-export PASSWORD="$(yq -r '.password' /root/data/start9/config.yaml)"
+export TITLE="$(yq e '.title' /root/data/start9/config.yaml)"
+export CUSTOM_USER="$(yq e '.username' /root/data/start9/config.yaml)"
+export PASSWORD="$(yq e '.password' /root/data/start9/config.yaml)"
 
 cat <<EOF >/root/data/start9/stats.yaml
 version: 2
@@ -35,40 +35,43 @@ if [ ! -f /config/.sparrow/config ]; then
   chown -R 1000:1000 /config/.sparrow
 fi
 
-case "$(yq -r '.server.type' /root/data/start9/config.yaml)" in
+case "$(yq e '.server.type' /root/data/start9/config.yaml)" in
 "bitcoind")
   echo "Configuring Sparrow for Bitcoin Core"
-  BITCOIND_USER=$(yq -r '.server.user' /root/data/start9/config.yaml)
-  BITCOIND_PASS=$(yq -r '.server.password' /root/data/start9/config.yaml)
-  cat /config/.sparrow/config | jq '.serverType = "BITCOIN_CORE"' | tee /config/.sparrow/config 1>/dev/null
-  cat /config/.sparrow/config | jq '.coreServer = "http://127.0.0.1:8332"' | tee /config/.sparrow/config 1>/dev/null
-  cat /config/.sparrow/config | jq '.coreAuthType = "USERPASS"' | tee /config/.sparrow/config 1>/dev/null
-  cat /config/.sparrow/config | jq ".coreAuth = \"${BITCOIND_USER}:${BITCOIND_PASS}\"" | tee /config/.sparrow/config 1>/dev/null
+  export BITCOIND_USER=$(yq e '.server.user' /root/data/start9/config.yaml)
+  export BITCOIND_PASS=$(yq e '.server.password' /root/data/start9/config.yaml)
+  yq e -i '
+    .serverType = "BITCOIN_CORE" |
+    .coreServer = "http://127.0.0.1:8332" |
+    .coreAuthType = "USERPASS" |
+    .coreAuth = strenv(BITCOIND_USER) + ":" + strenv(BITCOIND_PASS)' -o=json /config/.sparrow/config
   ;;
 "electrs")
   echo "Configuring Sparrow for Electrs"
-  cat /config/.sparrow/config | jq '.serverType = "ELECTRUM_SERVER"' | tee /config/.sparrow/config 1>/dev/null
-  cat /config/.sparrow/config | jq '.coreServer = "tcp://127.0.0.1:50001"' | tee /config/.sparrow/config 1>/dev/null
+  yq e -i '
+    .serverType = "ELECTRUM_SERVER" |
+    .coreServer = "tcp://127.0.0.1:50001"' -o=json /config/.sparrow/config
   ;;
 "public")
   echo "Configuring Sparrow for Public electrum server"
-  cat /config/.sparrow/config | jq '.serverType = "PUBLIC_ELECTRUM_SERVER"' | tee /config/.sparrow/config 1>/dev/null
+  yq e -i '.serverType = "PUBLIC_ELECTRUM_SERVER"' -o=json /config/.sparrow/config
   ;;
 *)
   echo "Custom server selected, not configuring Sparrow"
   ;;
 esac
 
-case "$(yq -r '.proxy.type' /root/data/start9/config.yaml)" in
+case "$(yq e '.proxy.type' /root/data/start9/config.yaml)" in
 "tor")
   echo "Configuring Sparrow for Tor"
-  EMBASSY_IP=$(ip -4 route list match 0/0 | awk '{print $3}')
-  cat /config/.sparrow/config | jq '.useProxy = true' | tee /config/.sparrow/config 1>/dev/null
-  cat /config/.sparrow/config | jq ".proxyServer = \"${EMBASSY_IP}:9050\"" | tee /config/.sparrow/config 1>/dev/null
+  export EMBASSY_IP=$(ip -4 route list match 0/0 | awk '{print $3}')
+  yq e -i '
+    .useProxy = true |
+    .proxyServer = strenv(EMBASSY_IP) + ":9050"' -o=json /config/.sparrow/config
   ;;
 "none")
   echo "Configuring Sparrow for 'no proxy'"
-  cat /config/.sparrow/config | jq '.useProxy = false' | tee /config/.sparrow/config 1>/dev/null
+  yq e -i '.useProxy = false' -o=json /config/.sparrow/config
   ;;
 *)
   echo "Custom proxy selected, not configuring Sparrow"

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -9,7 +9,7 @@ export TITLE="$(yq -r '.title' /root/data/start9/config.yaml)"
 export CUSTOM_USER="$(yq -r '.username' /root/data/start9/config.yaml)"
 export PASSWORD="$(yq -r '.password' /root/data/start9/config.yaml)"
 
-cat << EOF > /root/data/start9/stats.yaml
+cat <<EOF >/root/data/start9/stats.yaml
 version: 2
 data:
   "Username":
@@ -27,5 +27,53 @@ data:
     qr: false
     masked: true
 EOF
+
+if [ ! -f /config/.sparrow/config ]; then
+  echo "No Sparrow config file found, creating default"
+  mkdir -p /config/.sparrow
+  cp /defaults/.sparrow/config /config/.sparrow/config
+  chown -R 1000:1000 /config/.sparrow
+fi
+
+case "$(yq -r '.server.type' /root/data/start9/config.yaml)" in
+"bitcoind")
+  echo "Configuring Sparrow for Bitcoin Core"
+  BITCOIND_USER=$(yq -r '.server.user' /root/data/start9/config.yaml)
+  BITCOIND_PASS=$(yq -r '.server.password' /root/data/start9/config.yaml)
+  cat /config/.sparrow/config | jq '.serverType = "BITCOIN_CORE"' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.coreServer = "http://127.0.0.1:8332"' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.coreAuthType = "USERPASS"' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq ".coreAuth = \"${BITCOIND_USER}:${BITCOIND_PASS}\"" | tee /config/.sparrow/config
+  ;;
+"electrs")
+  echo "Configuring Sparrow for Electrs"
+  cat /config/.sparrow/config | jq '.serverType = "ELECTRUM_SERVER"' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.coreServer = "tcp://127.0.0.1:50001"' | tee /config/.sparrow/config
+  ;;
+"public")
+  echo "Configuring Sparrow for Public electrum server"
+  cat /config/.sparrow/config | jq '.serverType = "PUBLIC_ELECTRUM_SERVER"' | tee /config/.sparrow/config
+  ;;
+*)
+  echo "Custom server selected, not configuring Sparrow"
+  ;;
+esac
+
+case "$(yq -r '.proxy.type' /root/data/start9/config.yaml)" in
+"tor")
+  echo "Configuring Sparrow for Tor"
+  EMBASSY_IP=$(ip -4 route list match 0/0 | awk '{print $3}')
+  BITCOIND_USER=$(yq -r '.server.type' /root/data/start9/config.yaml)
+  cat /config/.sparrow/config | jq '.useProxy = true' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq ".proxyServer = \"${EMBASSY_IP}:9050\"" | tee /config/.sparrow/config
+  ;;
+"none")
+  echo "Configuring Sparrow for 'no proxy'"
+  cat /config/.sparrow/config | jq '.useProxy = false' | tee /config/.sparrow/config
+  ;;
+*)
+  echo "Custom proxy selected, not configuring Sparrow"
+  ;;
+esac
 
 exec /init

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -40,19 +40,19 @@ case "$(yq -r '.server.type' /root/data/start9/config.yaml)" in
   echo "Configuring Sparrow for Bitcoin Core"
   BITCOIND_USER=$(yq -r '.server.user' /root/data/start9/config.yaml)
   BITCOIND_PASS=$(yq -r '.server.password' /root/data/start9/config.yaml)
-  cat /config/.sparrow/config | jq '.serverType = "BITCOIN_CORE"' | tee /config/.sparrow/config
-  cat /config/.sparrow/config | jq '.coreServer = "http://127.0.0.1:8332"' | tee /config/.sparrow/config
-  cat /config/.sparrow/config | jq '.coreAuthType = "USERPASS"' | tee /config/.sparrow/config
-  cat /config/.sparrow/config | jq ".coreAuth = \"${BITCOIND_USER}:${BITCOIND_PASS}\"" | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.serverType = "BITCOIN_CORE"' | tee /config/.sparrow/config 1>/dev/null
+  cat /config/.sparrow/config | jq '.coreServer = "http://127.0.0.1:8332"' | tee /config/.sparrow/config 1>/dev/null
+  cat /config/.sparrow/config | jq '.coreAuthType = "USERPASS"' | tee /config/.sparrow/config 1>/dev/null
+  cat /config/.sparrow/config | jq ".coreAuth = \"${BITCOIND_USER}:${BITCOIND_PASS}\"" | tee /config/.sparrow/config 1>/dev/null
   ;;
 "electrs")
   echo "Configuring Sparrow for Electrs"
-  cat /config/.sparrow/config | jq '.serverType = "ELECTRUM_SERVER"' | tee /config/.sparrow/config
-  cat /config/.sparrow/config | jq '.coreServer = "tcp://127.0.0.1:50001"' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.serverType = "ELECTRUM_SERVER"' | tee /config/.sparrow/config 1>/dev/null
+  cat /config/.sparrow/config | jq '.coreServer = "tcp://127.0.0.1:50001"' | tee /config/.sparrow/config 1>/dev/null
   ;;
 "public")
   echo "Configuring Sparrow for Public electrum server"
-  cat /config/.sparrow/config | jq '.serverType = "PUBLIC_ELECTRUM_SERVER"' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.serverType = "PUBLIC_ELECTRUM_SERVER"' | tee /config/.sparrow/config 1>/dev/null
   ;;
 *)
   echo "Custom server selected, not configuring Sparrow"
@@ -63,13 +63,12 @@ case "$(yq -r '.proxy.type' /root/data/start9/config.yaml)" in
 "tor")
   echo "Configuring Sparrow for Tor"
   EMBASSY_IP=$(ip -4 route list match 0/0 | awk '{print $3}')
-  BITCOIND_USER=$(yq -r '.server.type' /root/data/start9/config.yaml)
-  cat /config/.sparrow/config | jq '.useProxy = true' | tee /config/.sparrow/config
-  cat /config/.sparrow/config | jq ".proxyServer = \"${EMBASSY_IP}:9050\"" | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.useProxy = true' | tee /config/.sparrow/config 1>/dev/null
+  cat /config/.sparrow/config | jq ".proxyServer = \"${EMBASSY_IP}:9050\"" | tee /config/.sparrow/config 1>/dev/null
   ;;
 "none")
   echo "Configuring Sparrow for 'no proxy'"
-  cat /config/.sparrow/config | jq '.useProxy = false' | tee /config/.sparrow/config
+  cat /config/.sparrow/config | jq '.useProxy = false' | tee /config/.sparrow/config 1>/dev/null
   ;;
 *)
   echo "Custom proxy selected, not configuring Sparrow"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -67,12 +67,14 @@ dependencies:
   bitcoind:
     version: ">=0.21.1.2 <28.0.0"
     requirement:
-      type: "required"
+      type: "opt-in"
+      how: "Select Bitcoin Core as the server"
     description: Used to connect Sparrow to a private Bitcoin Core server
   electrs:
     version: ">=0.9.6 <0.12.0"
     requirement:
-      type: "required"
+      type: "opt-out"
+      how: "Select Bitcoin Core or Public (not recommended) as the server"
     description: Used to connect Sparrow to a private electrum server
 backup:
   create:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 id: webtop-sparrow
 title: "Sparrow"
-version: 1.18.2.1
+version: 1.8.2.1
 release-notes: "Sparrow on Webtop for StartOS"
 license: GPLv3
 wrapper-repo: "https://github.com/remcoros/webtop-sparrow-startos"

--- a/root/defaults/.sparrow/config
+++ b/root/defaults/.sparrow/config
@@ -26,14 +26,17 @@
   "enumerateHwPeriod": 30,
   "useZbar": true,
   "serverType": "ELECTRUM_SERVER",
-  "coreServer": "http://bitcoind.embassy:8332",
+  "publicElectrumServer": "ssl://blockstream.info:700|blockstream.info",
+  "coreServer": "http://127.0.0.1:8332",
   "coreAuthType": "USERPASS",
+  "coreAuth": "user:password",
   "useLegacyCoreWallet": false,
-  "electrumServer": "tcp://electrs.embassy:50001",
+  "electrumServer": "tcp://127.0.0.1:50001",
   "recentElectrumServers": [
-    "tcp://electrs.embassy:50001"
+    "tcp://127.0.0.1:50001"
   ],
-  "useProxy": false,
+  "useProxy": true,
+  "proxyServer": "EMBASSY_IP:9050",
   "autoSwitchProxy": true,
   "maxServerTimeout": 34,
   "maxPageSize": 100,

--- a/root/defaults/.sparrow/config
+++ b/root/defaults/.sparrow/config
@@ -22,7 +22,6 @@
   "signBsmsExports": false,
   "preventSleep": false,
   "dustAttackThreshold": 1000,
-  "hwi": "/tmp/hwi-2.3.1434163966364527590.tmp",
   "enumerateHwPeriod": 30,
   "useZbar": true,
   "serverType": "ELECTRUM_SERVER",
@@ -32,11 +31,8 @@
   "coreAuth": "user:password",
   "useLegacyCoreWallet": false,
   "electrumServer": "tcp://127.0.0.1:50001",
-  "recentElectrumServers": [
-    "tcp://127.0.0.1:50001"
-  ],
   "useProxy": true,
-  "proxyServer": "EMBASSY_IP:9050",
+  "proxyServer": "",
   "autoSwitchProxy": true,
   "maxServerTimeout": 34,
   "maxPageSize": 100,

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,11 +1,6 @@
 #!/bin/bash
 
 # default file copies first run
-if [ ! -f $HOME/.sparrow/config ]; then
-    mkdir -p $HOME/.sparrow
-    cp /defaults/.sparrow/config $HOME/.sparrow/config
-fi
-
 if [ ! -f $HOME/.config/xfce4/xfconf/xfce-perchannel-xml/thunar.xml ]; then
     mkdir -p $HOME/.config/xfce4/xfconf/xfce-perchannel-xml
     cp /defaults/.config/xfce4/xfconf/xfce-perchannel-xml/thunar.xml $HOME/.config/xfce4/xfconf/xfce-perchannel-xml/thunar.xml
@@ -13,5 +8,10 @@ fi
 
 # open files and directories with thunar (file manager)
 xdg-mime default thunar.desktop inode/directory
+
+# setup a proxy on localhost, Sparrow will not use Tor for local addresses
+# this means we can connect straight to bitcoind/electrs and use Tor for everything else (whirlpool)
+/usr/bin/socat tcp-l:8332,fork,reuseaddr,bind=127.0.0.1 tcp:bitcoind.embassy:8332 &
+/usr/bin/socat tcp-l:50001,fork,reuseaddr,bind=127.0.0.1 tcp:electrs.embassy:50001 &
 
 /opt/sparrow/bin/Sparrow &

--- a/scripts/embassy.ts
+++ b/scripts/embassy.ts
@@ -2,4 +2,5 @@ export { setConfig } from "./procedures/setConfig.ts";
 export { getConfig } from "./procedures/getConfig.ts";
 export { properties } from "./procedures/properties.ts";
 export { migration } from "./procedures/migrations.ts";
+export { dependencies } from "./procedures/dependencies.ts";
 export { health } from "./procedures/healthChecks.ts";

--- a/scripts/procedures/dependencies.ts
+++ b/scripts/procedures/dependencies.ts
@@ -1,0 +1,30 @@
+import { matches, types as T } from "../deps.ts";
+
+const { shape, boolean } = matches;
+
+const matchBitcoindConfig = shape({
+  rpc: shape({
+    enable: boolean,
+  }),
+});
+
+export const dependencies: T.ExpectedExports.dependencies = {
+  bitcoind: {
+    // deno-lint-ignore require-await
+    async check(effects, configInput) {
+      effects.info("check bitcoind");
+      const config = matchBitcoindConfig.unsafeCast(configInput);
+      if (!config.rpc.enable) {
+        return { error: "Must have RPC enabled" };
+      }
+      return { result: null };
+    },
+    // deno-lint-ignore require-await
+    async autoConfigure(effects, configInput) {
+      effects.info("autoconfigure bitcoind");
+      const config = matchBitcoindConfig.unsafeCast(configInput);
+      config.rpc.enable = true;
+      return { result: config };
+    },
+  },
+};

--- a/scripts/procedures/getConfig.ts
+++ b/scripts/procedures/getConfig.ts
@@ -5,12 +5,13 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     "type": "string",
     "nullable": false,
     "name": "Webtop Title",
-    "description": "This value will be displayed as the title of your browser tab.",
+    "description":
+      "This value will be displayed as the title of your browser tab.",
     "default": "Start9 Sparrow on Webtop",
-    "pattern": "^[^\\n\"]*$",
+    "pattern": '^[^\\n"]*$',
     "pattern-description": "Must not contain newline or quote characters.",
     "masked": false,
-    "copyable": true
+    "copyable": true,
   },
   "username": {
     "type": "string",
@@ -18,10 +19,10 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
     "name": "Username",
     "description": "The username for logging into your Webtop.",
     "default": "webtop",
-    "pattern": "^[^\\n\"]*$",
+    "pattern": '^[^\\n"]*$',
     "pattern-description": "Must not contain newline or quote characters.",
     "masked": false,
-    "copyable": true
+    "copyable": true,
   },
   "password": {
     "type": "string",
@@ -33,8 +34,79 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
       charset: "a-z,1-9",
       len: 20,
     },
-    "pattern": "^[^\\n\"]*$",
+    "pattern": '^[^\\n"]*$',
     "pattern-description": "Must not contain newline or quote characters.",
-    "copyable": true
-  }
+    "copyable": true,
+  },
+  "server": {
+    "type": "union",
+    "name": "Bitcoin/Electrum Server",
+    "description":
+      "<p>The Bitcoin Core or Electrum node to connect to:</p><ul><li><strong>Public</strong>: Use a public Bitcoin node (not recommended!).</li><li><strong>Bitcoin Core</strong>: Use the Bitcoin Core service installed on your server.</li><li><strong>Electrs</strong>: Use the electrs service installed on your server.</li><li><strong>Custom</strong>: Do not change the current setting in Sparrow</li></ul>",
+    "tag": {
+      "id": "type",
+      "name": "Bitcoin Node Type",
+      "variant-names": {
+        "electrs": "Electrs (recommended)",
+        "bitcoind": "Bitcoin Core",
+        "public": "Public (not recommended)",
+        "custom": "Custom",
+      },
+      "description":
+        "<p>The Bitcoin Core or Electrum node to connect to:</p><ul><li><strong>Public</strong>: Use a public Bitcoin node (not recommended!).</li><li><strong>Bitcoin Core</strong>: Use the Bitcoin Core service installed on your server.</li><li><strong>Electrs</strong>: Use the electrs service installed on your server.</li><li><strong>Custom</strong>: Do not change the current setting in Sparrow</li></ul>",
+    },
+    "warning":
+      "If using 'Public', please switch to using Bitcoin Core or electrs as soon as possible. Using a public node can expose your IP address and transactions done using this node.",
+    "default": "electrs",
+    "variants": {
+      "electrs": {},
+      "bitcoind": {
+        "user": {
+          "type": "pointer",
+          "name": "RPC Username",
+          "description": "The username for Bitcoin Core's RPC interface",
+          "subtype": "package",
+          "package-id": "bitcoind",
+          "target": "config",
+          "multi": false,
+          "selector": "$.rpc.username",
+        },
+        "password": {
+          "type": "pointer",
+          "name": "RPC Password",
+          "description": "The password for Bitcoin Core's RPC interface",
+          "subtype": "package",
+          "package-id": "bitcoind",
+          "target": "config",
+          "multi": false,
+          "selector": "$.rpc.password",
+        },
+      },
+      "public": {},
+      "custom": {},
+    },
+  },
+  "proxy": {
+    "name": "Use a proxy",
+    "description":
+      "<p>Use a proxy for external connections (like whirlpool)</p><ul><li><strong>Tor</strong>: Use the Tor Proxy of StartOS (recommended)</li><li><strong>None</strong>: do not use a proxy (not recommended)</li><li><strong>Custom</strong>: Do not change the current setting in Sparrow</li></ul>",
+    "type": "union",
+    "tag": {
+      "id": "type",
+      "name": "Proxy Type",
+      "variant-names": {
+        "tor": "Tor (recommended)",
+        "none": "None (not recommended)",
+        "custom": "Custom",
+      },
+      "description":
+        "<p>Use a proxy for external connections (like whirlpool)</p><ul><li><strong>Tor</strong>: Use the Tor Proxy of StartOS (recommended)</li><li><strong>None</strong>: do not use a proxy (not recommended)</li><li><strong>Custom</strong>: Do not change the current setting in Sparrow</li></ul>",
+    },
+    "default": "tor",
+    "variants": {
+      "tor": {},
+      "none": {},
+      "custom": {},
+    },
+  },
 });

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -1,4 +1,4 @@
 import { compat, types as T } from "../deps.ts";
 
 export const migration: T.ExpectedExports.migration = compat.migrations
-    .fromMapping({}, "1.18.2.1" );
+    .fromMapping({}, "1.8.2.1" );

--- a/scripts/procedures/setConfig.ts
+++ b/scripts/procedures/setConfig.ts
@@ -1,3 +1,22 @@
 import { compat, types as T } from "../deps.ts";
 
-export const setConfig: T.ExpectedExports.setConfig = compat.setConfig;
+// Define a custom type for T.Config to include the 'server' property with a 'type' property
+interface SparrowConfig extends T.Config {
+  server?: {
+    type?: string;
+  };
+}
+
+// deno-lint-ignore require-await
+export const setConfig: T.ExpectedExports.setConfig = async (
+  effects: T.Effects,
+  newConfig: SparrowConfig,
+) => {
+  const depsBitcoind: { [key: string]: string[] } = newConfig?.server?.type === "bitcoind" ? { "bitcoind": [] } : {};
+  const depsElectrs: { [key: string]: string[] } = newConfig?.server?.type === "electrs" ? { "electrs": [] } : {};
+
+  return compat.setConfig(effects, newConfig, {
+    ...depsBitcoind,
+    ...depsElectrs,
+  });
+};


### PR DESCRIPTION
Added "Server" and "Proxy" settings.

Connects to the installed Bitcoin Core or Electrs instance on your StartOS trough a local proxy (using `socat` port forwarding).
This allows Sparrow to directly connect to a local instance, while still using a proxy (Tor) for remote connections like whirpool. 

Also properly handles dependencies now. Bitcoin Core and Electrs are opt-in/out based on the chosen settings.

Moved Sparrow PGP signature to Makefile, so it's defined in one place (instead of in the two Docker files)